### PR TITLE
fix prevent fatal from dnh_register_notice()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog ##
 
+## 2.1.4 - 25 Sept 2023
+* Prevent fatal after update
+
 ## 2.1.3 - 21 Sept 2023
 * Compat to PHP 8.1 change singleton functions declarations
 

--- a/bea-media-analytics.php
+++ b/bea-media-analytics.php
@@ -1,7 +1,7 @@
 <?php
 /*
  Plugin Name: BEA - Media Analytics
- Version: 2.1.3
+ Version: 2.1.4
  Plugin URI: https://github.com/BeAPI/bea-media-analytics
  Description: Find where and how media are used across your site.
  Author: Be API Technical team
@@ -35,7 +35,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Plugin constants
-define( 'BEA_MEDIA_ANALYTICS_VERSION', '2.1.3' );
+define( 'BEA_MEDIA_ANALYTICS_VERSION', '2.1.4' );
 define( 'BEA_MEDIA_ANALYTICS_MIN_PHP_VERSION', '5.6' );
 
 // Plugin URL and PATH

--- a/classes/plugin.php
+++ b/classes/plugin.php
@@ -39,7 +39,9 @@ class Plugin {
 			return;
 		}
 		add_action( 'admin_init', function () {
-			dnh_register_notice( sprintf( 'bea_media_analytics_activated_notice_%s', BEA_MEDIA_ANALYTICS_VERSION ), 'updated', _x( 'As BEA - Media Analytics plugin has been activated, the process of indexing contents will silently launch himself soon.', 'Admin notice', 'bea-media-analytics' ) );
+			if ( function_exists( 'dnh_register_notice' ) ) {
+				dnh_register_notice( sprintf( 'bea_media_analytics_activated_notice_%s', BEA_MEDIA_ANALYTICS_VERSION ), 'updated', _x( 'As BEA - Media Analytics plugin has been activated, the process of indexing contents will silently launch himself soon.', 'Admin notice', 'bea-media-analytics' ) );
+			}
 		} );
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -4,8 +4,8 @@ Donate link: http://paypal.me/BeAPI
 Tags: find, media, usage, find media, analytics
 Requires at least: 4.6
 Requires php: 5.6
-Tested up to: 4.9.3
-Stable tag: 2.1.2
+Tested up to: 6.1.3
+Stable tag: 2.1.4
 License: GPLv3 or later
 License URI: https://github.com/BeAPI/bea-media-analytics/blob/master/LICENSE.md
 


### PR DESCRIPTION
<!--
Thanks for contributing !

Please note :
- These comments won't show up when you submit the pull request.
- Please make sure your changes respect the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards).
- In case you introduced a new action or filter hook, please also include [inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php).
- Please provide tests, if you can.
-->

This pull request fixes issue #{id}.

It will apply the following changes :

* 
* 
* 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a simple `function_exists` guard around an optional admin-notice integration and bumps plugin metadata/version strings.
> 
> **Overview**
> Prevents a potential fatal error on admin init by only calling `dnh_register_notice()` when the function is available.
> 
> Bumps the plugin version to `2.1.4` and updates accompanying release metadata (`CHANGELOG.md`, `readme.txt` stable tag/tested-up-to).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c76c2a0d6a2170fbc05fb9b79354a741b43d0fe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->